### PR TITLE
HTTPS support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /deployster
+/ssl

--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@ Currently this project is in use for a few side projects, but is not in heavy pr
 * Deploy a new version of a service from the Docker registry (with optionally destroying the previously running version)
 * Shutdown a deployed version of a service
 * List all units associated to a service
+* Basic authentication and HTTPS support
 
 
 ### Requirements and limitations
@@ -29,7 +30,7 @@ To use Deployster, you'll need:
 
 After the above requirements are fulfilled, you can launch Deployster with Fleet.
 
-1. Using a unit file like this one, run `fleetctl start deployster.service`
+1. Using a unit file like this one (replacing `password` and `docker-hub-username`), run `fleetctl start deployster.service`
 
     ```
     [Unit]
@@ -40,6 +41,8 @@ After the above requirements are fulfilled, you can launch Deployster with Fleet
     TimeoutStartSec=0
     ExecStartPre=/usr/bin/docker pull bmorton/deployster
     ExecStartPre=-/usr/bin/docker rm -f deployster
+    # For HTTPS, put your certificate and private key in /home/core/ssl and add:
+    # `-v /home/core/ssl:/ssl` to docker options and `-cert=/ssl/server.crt -key=/ssl/server.key` to deployster options
     ExecStart=/usr/bin/docker run --name deployster -p 3000:3000 -v /var/run/fleet.sock:/var/run/fleet.sock bmorton/deployster -password=DONTUSETHIS -docker-hub-username=mycompany
     ExecStop=/usr/bin/docker rm -f deployster
     ```
@@ -85,24 +88,13 @@ After the above requirements are fulfilled, you can launch Deployster with Fleet
 ```ShellSession
 $ deployster -h
 Usage of deployster:
+  -cert="": Path to certificate to be used for serving HTTPS
   -docker-hub-username="": The username of the Docker Hub account that all deployable images are hosted under
+  -key="": Path to private key to bse used for serving HTTPS
   -listen="0.0.0.0:3000": Specifies the IP and port that the HTTP server will listen on
   -password="mmmhm": Password that will be used to authenticate with Deployster via HTTP basic auth
   -username="deployster": Username that will be used to authenticate with Deployster via HTTP basic auth
 ```
-
-
-### Todo
-
-* Move these todos to GitHub issues
-* Test coverage (started, but needs more ;/)
-* Documentation and more extensive examples/tutorials
-* HTTPS support
-* Vagrantfile for easy experimentation and testing
-* Allow tasks, such as `rake db:migrate` to be run before a deploy
-* Allow multiple instances to be started at once
-* Add support for multiple unit templates
-* Add support for Docker containers that need volumes linked (not stateless)
 
 
 ### Contributing

--- a/main.go
+++ b/main.go
@@ -38,6 +38,7 @@ func main() {
 	go func() {
 		var err error
 		if certPath != "" && keyPath != "" {
+			log.Println("Certificate and private key provided, HTTPS enabled.")
 			err = service.ListenAndServeTLS(certPath, keyPath)
 		} else {
 			err = service.ListenAndServe()

--- a/main.go
+++ b/main.go
@@ -4,6 +4,9 @@ import (
 	"flag"
 	"github.com/bmorton/deployster/server"
 	"log"
+	"os"
+	"os/signal"
+	"syscall"
 )
 
 // A version string that can be set at compile time with:
@@ -15,17 +18,36 @@ var listen string
 var dockerHubUsername string
 var username string
 var password string
+var certPath string
+var keyPath string
 
 func init() {
 	flag.StringVar(&listen, "listen", "0.0.0.0:3000", "Specifies the IP and port that the HTTP server will listen on")
 	flag.StringVar(&dockerHubUsername, "docker-hub-username", "", "The username of the Docker Hub account that all deployable images are hosted under")
 	flag.StringVar(&username, "username", "deployster", "Username that will be used to authenticate with Deployster via HTTP basic auth")
 	flag.StringVar(&password, "password", "mmmhm", "Password that will be used to authenticate with Deployster via HTTP basic auth")
+	flag.StringVar(&certPath, "cert", "", "Path to certificate to be used for serving HTTPS")
+	flag.StringVar(&keyPath, "key", "", "Path to private key to bse used for serving HTTPS")
 	flag.Parse()
 }
 
 func main() {
 	log.Printf("Starting deployster on %s...\n", listen)
 	service := server.NewDeploysterService(listen, AppVersion, username, password, dockerHubUsername)
-	service.ListenAndServe()
+
+	go func() {
+		var err error
+		if certPath != "" && keyPath != "" {
+			err = service.ListenAndServeTLS(certPath, keyPath)
+		} else {
+			err = service.ListenAndServe()
+		}
+		if err != nil {
+			log.Println(err)
+		}
+	}()
+	ch := make(chan os.Signal)
+	signal.Notify(ch, syscall.SIGINT, syscall.SIGQUIT, syscall.SIGTERM)
+	log.Println(<-ch)
+	service.Close()
 }

--- a/server/deployster_service.go
+++ b/server/deployster_service.go
@@ -46,8 +46,16 @@ func (ds *DeploysterService) ConfigureRoutes() {
 	ds.Mux.Handle("GET", "/services/{name}/units", ds.authenticated(tigertonic.Marshaled(units.Index)))
 }
 
-func (ds *DeploysterService) ListenAndServe() {
-	ds.Server.ListenAndServe()
+func (ds *DeploysterService) ListenAndServe() error {
+	return ds.Server.ListenAndServe()
+}
+
+func (ds *DeploysterService) ListenAndServeTLS(certPath string, keyPath string) error {
+	return ds.Server.ListenAndServeTLS(certPath, keyPath)
+}
+
+func (ds *DeploysterService) Close() error {
+	return ds.Server.Close()
 }
 
 func (ds *DeploysterService) authenticated(h http.Handler) tigertonic.FirstHandler {


### PR DESCRIPTION
This pull request adds support for passing a certificate and private key via command line arguments to force the service to serve traffic over HTTPS.

Running deployster in HTTPS mode can be done like this:

```
$ deployster -password=myawesomepassword -docker-hub-username=mmmhm -cert=/ssl/server.crt -key=/ssl/server.key
2015/01/07 10:12:49 Starting deployster on 0.0.0.0:3000...
```

### Todo

- [x] Add startup output to show which mode the server is running in