### PR TITLE
Custom tasks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,10 +3,12 @@
 Features:
 
   * HTTPS support
+  * Custom task launching for doing things like migrating a database using a given service image and version ([#14][issue-14])
 
 Fixes:
 
   * Improve code to be more idiomatic
+  * More documentation and test coverage
 
 
 ## v0.1.0
@@ -17,3 +19,5 @@ Features:
   * Shutdown a deployed version of a service
   * List all units associated to a service
   * HTTP basic authentication for all endpoints
+
+[issue-14]: https://github.com/bmorton/deployster/pull/14

--- a/README.md
+++ b/README.md
@@ -27,6 +27,11 @@ To use Deployster, you'll need:
 * **Automatic environment configuration** - As we're currently reusing the same unit file for all services, environment variables can't be passed to containers at boot, so containers need to use something like [etcd], [consul], or [confd][confd] to bootstrap themselves at launch.
 
 
+#### Task limitations
+
+Tasks are limited to 10 minutes of running time, after which they will be forcefully removed.  If the task is killed, it will have an exit code of 124.  In the future, this timeout may be configurable per task to override the default timeout.
+
+
 ### Getting started
 
 After the above requirements are fulfilled, you can launch Deployster with Fleet.

--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ Currently this project is in use for a few side projects, but is not in heavy pr
 * Shutdown a deployed version of a service
 * List all units associated to a service
 * Basic authentication and HTTPS support
+* Custom task launching for doing things like [migrating a database][running-rails-migrations] using a given service image and version
 
 
 ### Requirements and limitations
@@ -56,7 +57,19 @@ After the above requirements are fulfilled, you can launch Deployster with Fleet
     railsapp-9f88701@1.service  8dcea1bd.../100.10.11.1  active  running
     ```
 
-3. Deploy an updated version while automatically destroying the previous version once the new one is online
+3. Run a custom task, like migrating the database, using the same conventions
+
+    ```ShellSession
+    $ curl -XPOST http://localhost:3000/v1/services/railsapp/tasks -H "Content-Type: application/json" -d '{"task":{"version":"7bdae1c", "command":"bundle exec rake db:migrate"}}' -u deployster:DONTUSETHIS
+    == 20150118005051 CreateUsers: migrating =====================================
+    -- create_table(:users)
+       -> 0.0017s
+    == 20150118005051 CreateUsers: migrated (0.0018s) ============================
+
+    Exited (0)
+    ```
+
+4. Deploy an updated version while automatically destroying the previous version once the new one is online
 
     ```ShellSession
     $ curl -XPOST http://localhost:3000/v1/services/railsapp/deploys -H "Content-Type: application/json" -d '{"deploy":{"version":"7bdae1c", "destroy_previous": true}}' -u deployster:DONTUSETHIS
@@ -69,14 +82,14 @@ After the above requirements are fulfilled, you can launch Deployster with Fleet
     railsapp-7bdae1c@1.service  8dcea1bd.../100.10.11.1  active  running
     ```
 
-4. List units associated to a service
+5. List units associated to a service
 
     ```ShellSession
     $ curl http://localhost:3000/v1/services/railsapp/units -u deployster:DONTUSETHIS
     {"units":[{"service":"railsapp","instance":"1","version":"7bdae1c","current_state":"launched","desired_state":"launched","machine_id":"8dcea1bd8c304e1bbe2c25dce526109c"}]}
     ```
 
-5. Manually shutdown a version of a service
+6. Manually shutdown a version of a service
 
     ```ShellSession
     $ curl -XDELETE http://localhost:3000/v1/services/railsapp/deploys/7bdae1c -u deployster:DONTUSETHIS
@@ -109,6 +122,7 @@ Code and documentation copyright 2015 Brian Morton. Code released under the MIT 
 [fleet-cluster]: https://coreos.com/using-coreos/clustering/
 [deployster-docker-hub]: https://registry.hub.docker.com/u/bmorton/deployster/
 [yammer]: https://www.yammer.com
+[running-rails-migrations]: http://guides.rubyonrails.org/active_record_migrations.html#running-migrations
 [digitalocean]: https://www.digitalocean.com/community/tutorials/how-to-set-up-a-coreos-cluster-on-digitalocean
 [azure]: https://coreos.com/docs/running-coreos/cloud-providers/azure
 [registry-authentication]: https://coreos.com/docs/launching-containers/building/registry-authentication/

--- a/server/deployster_service.go
+++ b/server/deployster_service.go
@@ -47,7 +47,7 @@ func (ds *DeploysterService) ConfigureRoutes() {
 	ds.Mux.Handle("POST", "/services/{name}/deploys", ds.authenticated(tigertonic.Marshaled(deploys.Create)))
 	ds.Mux.Handle("DELETE", "/services/{name}/deploys/{version}", ds.authenticated(tigertonic.Marshaled(deploys.Destroy)))
 	ds.Mux.Handle("GET", "/services/{name}/units", ds.authenticated(tigertonic.Marshaled(units.Index)))
-	ds.Mux.Handle("POST", "/services/{name}/tasks", ds.authenticated(tigertonic.Marshaled(tasks.Create)))
+	ds.Mux.Handle("POST", "/services/{name}/tasks", ds.authenticated(http.HandlerFunc(tasks.Create)))
 }
 
 func (ds *DeploysterService) ListenAndServe() error {

--- a/server/flush_writer.go
+++ b/server/flush_writer.go
@@ -25,6 +25,8 @@ func (fw *flushWriter) Write(p []byte) (n int, err error) {
 	return
 }
 
+// newFlushWriter creates a flushWriter using the io.Writer provided as the
+// writer and flusher.
 func newFlushWriter(w io.Writer) flushWriter {
 	fw := flushWriter{writer: w}
 	if f, ok := w.(http.Flusher); ok {

--- a/server/flush_writer.go
+++ b/server/flush_writer.go
@@ -1,0 +1,19 @@
+package server
+
+import (
+	"io"
+	"net/http"
+)
+
+type flushWriter struct {
+	f http.Flusher
+	w io.Writer
+}
+
+func (fw *flushWriter) Write(p []byte) (n int, err error) {
+	n, err = fw.w.Write(p)
+	if fw.f != nil {
+		fw.f.Flush()
+	}
+	return
+}

--- a/server/flush_writer.go
+++ b/server/flush_writer.go
@@ -5,15 +5,22 @@ import (
 	"net/http"
 )
 
+// flushWriter is used to stream responses to the provided io.Writer instead of
+// buffering and sending in blocks once the request is fully processed.
+//
+// The implementation comes from this StackOverflow post:
+// http://stackoverflow.com/questions/19292113/not-buffered-http-responsewritter-in-golang
 type flushWriter struct {
-	f http.Flusher
-	w io.Writer
+	flusher http.Flusher
+	writer  io.Writer
 }
 
+// Write satisifies the io.Writer interface so that flushWriter can wrap the
+// supplied io.Writer with a Flusher.
 func (fw *flushWriter) Write(p []byte) (n int, err error) {
-	n, err = fw.w.Write(p)
-	if fw.f != nil {
-		fw.f.Flush()
+	n, err = fw.writer.Write(p)
+	if fw.flusher != nil {
+		fw.flusher.Flush()
 	}
 	return
 }

--- a/server/flush_writer.go
+++ b/server/flush_writer.go
@@ -24,3 +24,12 @@ func (fw *flushWriter) Write(p []byte) (n int, err error) {
 	}
 	return
 }
+
+func newFlushWriter(w io.Writer) flushWriter {
+	fw := flushWriter{writer: w}
+	if f, ok := w.(http.Flusher); ok {
+		fw.flusher = f
+	}
+
+	return fw
+}

--- a/server/mocks/docker_client.go
+++ b/server/mocks/docker_client.go
@@ -1,0 +1,46 @@
+package mocks
+
+import "github.com/stretchr/testify/mock"
+import "github.com/fsouza/go-dockerclient"
+
+type DockerClient struct {
+	mock.Mock
+}
+
+func (m *DockerClient) RemoveContainer(_a0 docker.RemoveContainerOptions) error {
+	ret := m.Called(_a0)
+
+	r0 := ret.Error(0)
+
+	return r0
+}
+func (m *DockerClient) CreateContainer(_a0 docker.CreateContainerOptions) (*docker.Container, error) {
+	ret := m.Called(_a0)
+
+	r0 := ret.Get(0).(*docker.Container)
+	r1 := ret.Error(1)
+
+	return r0, r1
+}
+func (m *DockerClient) StartContainer(_a0 string, _a1 *docker.HostConfig) error {
+	ret := m.Called(_a0, _a1)
+
+	r0 := ret.Error(0)
+
+	return r0
+}
+func (m *DockerClient) AttachToContainer(_a0 docker.AttachToContainerOptions) error {
+	ret := m.Called(_a0)
+
+	r0 := ret.Error(0)
+
+	return r0
+}
+func (m *DockerClient) InspectContainer(_a0 string) (*docker.Container, error) {
+	ret := m.Called(_a0)
+
+	r0 := ret.Get(0).(*docker.Container)
+	r1 := ret.Error(1)
+
+	return r0, r1
+}

--- a/server/tasks_resource.go
+++ b/server/tasks_resource.go
@@ -1,0 +1,27 @@
+package server
+
+import (
+	"net/http"
+	"net/url"
+
+	"github.com/fsouza/go-dockerclient"
+)
+
+type TasksResource struct {
+	Docker            *docker.Client
+	DockerHubUsername string
+}
+
+type TaskRequest struct {
+	Task Task `json:"task"`
+}
+
+type Task struct {
+	Version string `json:"version"`
+	Command string `json:"command"`
+}
+
+func (tr *TasksResource) Create(u *url.URL, h http.Header, req *TaskRequest) (int, http.Header, interface{}, error) {
+
+	return http.StatusCreated, nil, nil, nil
+}

--- a/server/tasks_resource.go
+++ b/server/tasks_resource.go
@@ -1,6 +1,9 @@
 package server
 
 import (
+	"bytes"
+	"fmt"
+	"log"
 	"net/http"
 	"net/url"
 
@@ -22,6 +25,44 @@ type Task struct {
 }
 
 func (tr *TasksResource) Create(u *url.URL, h http.Header, req *TaskRequest) (int, http.Header, interface{}, error) {
+	serviceName := u.Query().Get("name")
+	taskName := fmt.Sprintf("%s-%s-task", serviceName, req.Task.Version)
+	imageName := fmt.Sprintf("%s/%s:%s", tr.DockerHubUsername, serviceName, req.Task.Version)
+
+	container, err := tr.Docker.CreateContainer(docker.CreateContainerOptions{
+		Name: taskName,
+		Config: &docker.Config{
+			Image:        imageName,
+			Cmd:          []string{req.Task.Command},
+			AttachStdout: true,
+			AttachStderr: true,
+		},
+	})
+	if err != nil {
+		return http.StatusInternalServerError, nil, nil, err
+	}
+
+	log.Printf("%#v", container)
+	tr.Docker.StartContainer(container.ID, &docker.HostConfig{})
+
+	var buf bytes.Buffer
+	err = tr.Docker.AttachToContainer(docker.AttachToContainerOptions{
+		Container:    container.ID,
+		OutputStream: &buf,
+		Logs:         true,
+		Stdout:       true,
+		Stderr:       true,
+		Stream:       true,
+	})
+	if err != nil {
+		return http.StatusInternalServerError, nil, nil, err
+	}
+	log.Println(buf.String())
+
+	err = tr.Docker.RemoveContainer(docker.RemoveContainerOptions{ID: container.ID})
+	if err != nil {
+		return http.StatusInternalServerError, nil, nil, err
+	}
 
 	return http.StatusCreated, nil, nil, nil
 }

--- a/server/tasks_resource.go
+++ b/server/tasks_resource.go
@@ -19,6 +19,8 @@ type TasksResource struct {
 	DockerHubUsername string
 }
 
+// DockerClient is the interface required for TasksResource to be able to
+// create, start, attach, inspect, and remove Docker containers.
 type DockerClient interface {
 	CreateContainer(docker.CreateContainerOptions) (*docker.Container, error)
 	StartContainer(string, *docker.HostConfig) error

--- a/server/tasks_resource_test.go
+++ b/server/tasks_resource_test.go
@@ -1,0 +1,130 @@
+package server
+
+import (
+	"bytes"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bmorton/deployster/server/mocks"
+	"github.com/fsouza/go-dockerclient"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/mock"
+	"github.com/stretchr/testify/suite"
+)
+
+type TasksResourceTestSuite struct {
+	suite.Suite
+	Subject          TasksResource
+	DockerClientMock *mocks.DockerClient
+	Service          *DeploysterService
+}
+
+var validRequestBody []byte = []byte(`{"task":{"version":"abc123", "command":"bundle exec rake db:migrate"}}`)
+
+func (suite *TasksResourceTestSuite) SetupSuite() {
+	suite.Service = NewDeploysterService("0.0.0.0:3000", "v1.0", "username", "password", "mmmhm")
+}
+
+func (suite *TasksResourceTestSuite) SetupTest() {
+	suite.DockerClientMock = new(mocks.DockerClient)
+	suite.Subject = TasksResource{suite.DockerClientMock, "mmmhm"}
+}
+
+func (suite *TasksResourceTestSuite) TestCreateTellsDockerToCreateContainer() {
+	suite.setupSuccessfulDockerMock()
+	req, _ := http.NewRequest("POST", "http://example.com/services/carousel/tasks?name=carousel", bytes.NewBuffer(validRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	suite.Subject.Create(w, req)
+
+	suite.DockerClientMock.Mock.AssertCalled(suite.T(), "CreateContainer", docker.CreateContainerOptions{
+		Name: "carousel-abc123-task",
+		Config: &docker.Config{
+			Image:        "mmmhm/carousel:abc123",
+			Cmd:          []string{"bundle exec rake db:migrate"},
+			AttachStdout: true,
+			AttachStderr: true,
+		},
+	})
+}
+
+func (suite *TasksResourceTestSuite) TestCreateTellsDockerToStartContainer() {
+	suite.setupSuccessfulDockerMock()
+	req, _ := http.NewRequest("POST", "http://example.com/services/carousel/tasks?name=carousel", bytes.NewBuffer(validRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	suite.Subject.Create(w, req)
+
+	suite.DockerClientMock.Mock.AssertCalled(suite.T(), "StartContainer", "c0c0c0c0c0", &docker.HostConfig{})
+}
+
+func (suite *TasksResourceTestSuite) TestCreateAttachesToContainer() {
+	suite.setupSuccessfulDockerMock()
+	req, _ := http.NewRequest("POST", "http://example.com/services/carousel/tasks?name=carousel", bytes.NewBuffer(validRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	suite.Subject.Create(w, req)
+	fw := newFlushWriter(w)
+
+	suite.DockerClientMock.Mock.AssertCalled(suite.T(), "AttachToContainer", docker.AttachToContainerOptions{
+		Container:    "c0c0c0c0c0",
+		OutputStream: &fw,
+		ErrorStream:  &fw,
+		Logs:         true,
+		Stdout:       true,
+		Stderr:       true,
+		Stream:       true,
+	})
+}
+
+func (suite *TasksResourceTestSuite) TestCreateInspectsContainerForExitStatus() {
+	suite.setupSuccessfulDockerMock()
+	req, _ := http.NewRequest("POST", "http://example.com/services/carousel/tasks?name=carousel", bytes.NewBuffer(validRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	suite.Subject.Create(w, req)
+
+	suite.DockerClientMock.Mock.AssertCalled(suite.T(), "InspectContainer", "c0c0c0c0c0")
+}
+
+func (suite *TasksResourceTestSuite) TestCreateIsSuccessfulWhenContainerStarted() {
+	suite.setupSuccessfulDockerMock()
+	req, _ := http.NewRequest("POST", "http://example.com/services/carousel/tasks?name=carousel", bytes.NewBuffer(validRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	suite.Subject.Create(w, req)
+
+	assert.Equal(suite.T(), 200, w.Code)
+}
+
+func (suite *TasksResourceTestSuite) TestCreateReturnsServerErrorWhenContainerFailsToStart() {
+	suite.DockerClientMock.On("CreateContainer", mock.AnythingOfType("docker.CreateContainerOptions")).Return(&docker.Container{ID: "c123d123bb"}, nil)
+	suite.DockerClientMock.On("StartContainer", "c123d123bb", &docker.HostConfig{}).Return(errors.New("failed"))
+
+	req, _ := http.NewRequest("POST", "http://example.com/services/carousel/tasks?name=carousel", bytes.NewBuffer(validRequestBody))
+	req.Header.Set("Content-Type", "application/json")
+
+	w := httptest.NewRecorder()
+	suite.Subject.Create(w, req)
+
+	assert.Equal(suite.T(), 500, w.Code)
+}
+
+func TestTasksResourceTestSuite(t *testing.T) {
+	suite.Run(t, new(TasksResourceTestSuite))
+}
+
+func (suite *TasksResourceTestSuite) setupSuccessfulDockerMock() {
+	suite.DockerClientMock.On("CreateContainer", mock.AnythingOfType("docker.CreateContainerOptions")).Return(&docker.Container{ID: "c0c0c0c0c0"}, nil)
+	suite.DockerClientMock.On("StartContainer", "c0c0c0c0c0", &docker.HostConfig{}).Return(nil)
+	suite.DockerClientMock.On("AttachToContainer", mock.AnythingOfType("docker.AttachToContainerOptions")).Return(nil)
+	suite.DockerClientMock.On("InspectContainer", "c0c0c0c0c0").Return(&docker.Container{}, nil)
+	suite.DockerClientMock.On("RemoveContainer", mock.AnythingOfType("docker.RemoveContainerOptions")).Return(nil)
+}


### PR DESCRIPTION
This is the work-in-progress attempt at addressing #5.

### Current progress

* Talks to Docker API at `/var/run/docker.sock` to create a container, start it up, and attach to it.
* ~~Sends output from Docker container via HTTP response, but only when the task has completely finished~~ Streams output from Docker container via HTTP response, providing a `200 OK` if the container launches successfully, regardless of the exit code of the task.  So that the exit code of the task can be acted upon by the client, it is streamed at the end of the HTTP response as "Exited (code) [possible error]".
* Removes Docker container when done

### Todo

* [x] Set a max timeout to automatically force remove container if task doesn't finish within time
* [x] ~~Optionally disable container cleanup through request~~ I'm not convinced this is needed for v1.  We can add this later if people start requesting it (or if we end up needing it for debugging).
* [x] Test coverage
* [x] Add to README/CHANGELOG
