### PR TITLE
Rename DockerHubUsername to ImagePrefix within service and resources

### DIFF
--- a/server/deployster_service.go
+++ b/server/deployster_service.go
@@ -8,24 +8,33 @@ import (
 	"github.com/rcrowley/go-tigertonic"
 )
 
+// DeploysterService is the HTTP server that ties together all the resources,
+// configures routing and dependencies, and authenticates requests.  The server
+// will listen for requests in the address:port that is passed as the listen
+// string.  The provided username/password will be used for HTTP basic auth for
+// all requests.  An image prefix can be either a private registry address:port
+// or a username on the public registry (basically something that'll be appended
+// to the service name, e.g. mmmmhm/servicename or my.registry:5000/servicename).
 type DeploysterService struct {
-	AppVersion        string
-	Listen            string
-	Username          string
-	Password          string
-	DockerHubUsername string
-	RootMux           *tigertonic.TrieServeMux
-	Mux               *tigertonic.TrieServeMux
-	Server            *tigertonic.Server
+	AppVersion  string
+	Listen      string
+	Username    string
+	Password    string
+	ImagePrefix string
+	RootMux     *tigertonic.TrieServeMux
+	Mux         *tigertonic.TrieServeMux
+	Server      *tigertonic.Server
 }
 
-func NewDeploysterService(listen string, version string, username string, password string, dockerHubUsername string) *DeploysterService {
+// NewDeploysterService returns a configured DeploysterService, ready to listen
+// for HTTP requests via the provided listen string.
+func NewDeploysterService(listen string, version string, username string, password string, imagePrefix string) *DeploysterService {
 	service := DeploysterService{
-		Listen:            listen,
-		AppVersion:        version,
-		Username:          username,
-		Password:          password,
-		DockerHubUsername: dockerHubUsername,
+		Listen:      listen,
+		AppVersion:  version,
+		Username:    username,
+		Password:    password,
+		ImagePrefix: imagePrefix,
 	}
 	service.RootMux = tigertonic.NewTrieServeMux()
 	service.Mux = tigertonic.NewTrieServeMux()
@@ -36,12 +45,14 @@ func NewDeploysterService(listen string, version string, username string, passwo
 	return &service
 }
 
+// ConfigureRoutes sets up resources and their dependencies so that we can
+// configure all the HTTP routes that will be supported by the server.
 func (ds *DeploysterService) ConfigureRoutes() {
 	fleetClient := fleet.NewClient("/var/run/fleet.sock")
 	dockerClient, _ := docker.NewClient("unix:///var/run/docker.sock")
-	deploys := DeploysResource{&fleetClient, ds.DockerHubUsername}
+	deploys := DeploysResource{&fleetClient, ds.ImagePrefix}
 	units := UnitsResource{&fleetClient}
-	tasks := TasksResource{dockerClient, ds.DockerHubUsername}
+	tasks := TasksResource{dockerClient, ds.ImagePrefix}
 
 	ds.Mux.Handle("GET", "/version", ds.authenticated(tigertonic.Version(ds.AppVersion)))
 	ds.Mux.Handle("POST", "/services/{name}/deploys", ds.authenticated(tigertonic.Marshaled(deploys.Create)))
@@ -50,18 +61,22 @@ func (ds *DeploysterService) ConfigureRoutes() {
 	ds.Mux.Handle("POST", "/services/{name}/tasks", ds.authenticated(http.HandlerFunc(tasks.Create)))
 }
 
+// ListenAndServe starts the HTTP server.
 func (ds *DeploysterService) ListenAndServe() error {
 	return ds.Server.ListenAndServe()
 }
 
+// ListenAndServe starts the HTTPS server with the given certificate and key.
 func (ds *DeploysterService) ListenAndServeTLS(certPath string, keyPath string) error {
 	return ds.Server.ListenAndServeTLS(certPath, keyPath)
 }
 
+// Close gracefully stops listening for new requests
 func (ds *DeploysterService) Close() error {
 	return ds.Server.Close()
 }
 
+// authenticated wraps an HTTP handler with HTTP basic authentication
 func (ds *DeploysterService) authenticated(h http.Handler) tigertonic.FirstHandler {
 	return tigertonic.HTTPBasicAuth(
 		map[string]string{ds.Username: ds.Password},

--- a/server/tasks_resource.go
+++ b/server/tasks_resource.go
@@ -12,12 +12,12 @@ import (
 
 // TasksResource is the HTTP resource responsible for launching new tasks via
 // the Docker API in an opinionated and conventional way.  Using the provided
-// DockerHubUsername and the payload passed to the Create endpoint, we can
-// construct the image name to pull from the Docker Hub Registry so that the
-// task can be launched.
+// ImagePrefix and the payload passed to the Create endpoint, we can construct
+// the image name to pull from the Docker Hub Registry so that the task can be
+// launched.
 type TasksResource struct {
-	Docker            DockerClient
-	DockerHubUsername string
+	Docker      DockerClient
+	ImagePrefix string
 }
 
 // DockerClient is the interface required for TasksResource to be able to
@@ -69,7 +69,7 @@ func (tr *TasksResource) Create(w http.ResponseWriter, r *http.Request) {
 	}
 	serviceName := r.URL.Query().Get("name")
 	taskName := fmt.Sprintf("%s-%s-task", serviceName, req.Task.Version)
-	imageName := fmt.Sprintf("%s/%s:%s", tr.DockerHubUsername, serviceName, req.Task.Version)
+	imageName := fmt.Sprintf("%s/%s:%s", tr.ImagePrefix, serviceName, req.Task.Version)
 
 	container, err := tr.runContainer(taskName, imageName, req.Task.Command)
 	if err != nil {

--- a/server/templates.go
+++ b/server/templates.go
@@ -9,9 +9,9 @@ After=docker.service
 EnvironmentFile=/etc/environment
 User=core
 TimeoutStartSec=0
-ExecStartPre=/usr/bin/docker pull {{.DockerHubUsername}}/{{.Name}}:{{.Version}}
+ExecStartPre=/usr/bin/docker pull {{.ImagePrefix}}/{{.Name}}:{{.Version}}
 ExecStartPre=-/usr/bin/docker rm -f {{.Name}}-{{.Version}}-%i
-ExecStart=/usr/bin/docker run --name {{.Name}}-{{.Version}}-%i -p 3000 {{.DockerHubUsername}}/{{.Name}}:{{.Version}}
+ExecStart=/usr/bin/docker run --name {{.Name}}-{{.Version}}-%i -p 3000 {{.ImagePrefix}}/{{.Name}}:{{.Version}}
 ExecStartPost=/bin/sh -c "sleep 15; /usr/bin/etcdctl set /vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-%i http://$COREOS_PRIVATE_IPV4:$(echo $(/usr/bin/docker port {{.Name}}-{{.Version}}-%i 3000) | cut -d ':' -f 2)"
 ExecStop=/bin/sh -c "/usr/bin/etcdctl rm '/vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-%i' ; /usr/bin/docker rm -f {{.Name}}-{{.Version}}-%i"
 `


### PR DESCRIPTION
To prepare for accepting both a Docker Hub username as well as a private registry URL, I'm simplifying the input that the service and resources take so that its simply an image prefix, which can be either the username or the registry URL.

This will allow flags for either to be passed and supplied as the image prefix.  We could have one flag in the CLI that could be used for either option, but that might be slightly confusing to the user, so we'll provide this small abstraction for it.