### PR TITLE
Use the LastIndex of '-' in the unit name so that we can support service names with hyphens

### DIFF
--- a/server/extractable_unit.go
+++ b/server/extractable_unit.go
@@ -14,8 +14,8 @@ type ExtractableUnit fleet.Unit
 // ExtractBaseName returns the name of the service from the Fleet unit name.
 // Given "railsapp-cf2e8ac@1.service" this returns "railsapp"
 func (eu *ExtractableUnit) ExtractBaseName() string {
-	s := strings.Split(eu.Name, "-")
-	return s[0]
+	s := strings.LastIndex(eu.Name, "-")
+	return eu.Name[0:s]
 }
 
 // ExtractVersion returns the version of the service from the Fleet unit name.

--- a/server/extractable_unit_test.go
+++ b/server/extractable_unit_test.go
@@ -15,6 +15,11 @@ func (suite *ExtractableUnitTestSuite) TestExtractsBaseName() {
 	assert.Equal(suite.T(), "railsapp", subject.ExtractBaseName())
 }
 
+func (suite *ExtractableUnitTestSuite) TestExtractsBaseNameSupportsNamesWithHyphens() {
+	subject := ExtractableUnit{Name: "hello-world-efe1abc@1.service"}
+	assert.Equal(suite.T(), "hello-world", subject.ExtractBaseName())
+}
+
 func (suite *ExtractableUnitTestSuite) TestExtractsVersion() {
 	subject := ExtractableUnit{Name: "railsapp-efe1abc@1.service"}
 	assert.Equal(suite.T(), "efe1abc", subject.ExtractVersion())


### PR DESCRIPTION
This fixes #26 and replaces the string split of an extractable base name with a lookup for the last index of the `-` separator.