### PR TITLE
Fix panic when checking the version of a service with a hyphenated name

### DIFF
--- a/server/extractable_unit.go
+++ b/server/extractable_unit.go
@@ -21,9 +21,9 @@ func (eu *ExtractableUnit) ExtractBaseName() string {
 // ExtractVersion returns the version of the service from the Fleet unit name.
 // Given "railsapp-cf2e8ac@1.service" this returns "cf2e8ac"
 func (eu *ExtractableUnit) ExtractVersion() string {
-	s := strings.Split(eu.Name, "-")
-	end := strings.Index(s[1], "@")
-	return s[1][:end]
+	start := strings.LastIndex(eu.Name, "-")
+	end := strings.LastIndex(eu.Name, "@")
+	return eu.Name[start+1 : end]
 }
 
 // ExtractInstance returns the instance of the service from the Fleet unit name.

--- a/server/extractable_unit_test.go
+++ b/server/extractable_unit_test.go
@@ -25,6 +25,11 @@ func (suite *ExtractableUnitTestSuite) TestExtractsVersion() {
 	assert.Equal(suite.T(), "efe1abc", subject.ExtractVersion())
 }
 
+func (suite *ExtractableUnitTestSuite) TestExtractsVersionWithHyphenatedName() {
+	subject := ExtractableUnit{Name: "hellow-world-efe1abc@1.service"}
+	assert.Equal(suite.T(), "efe1abc", subject.ExtractVersion())
+}
+
 func (suite *ExtractableUnitTestSuite) TestExtractsInstance() {
 	subject := ExtractableUnit{Name: "railsapp-efe1abc@1.service"}
 	assert.Equal(suite.T(), "1", subject.ExtractInstance())


### PR DESCRIPTION
Due to the fix in #27, we inadvertently caused a new bug to be introduced that caused a panic when checking the version of a service with a hyphenated name.  This fixes that bug and adds a test to cover the failure.