### PR TITLE
Support for deploying multiple units of a service

### DIFF
--- a/server/clients.go
+++ b/server/clients.go
@@ -20,4 +20,5 @@ type FleetClient interface {
 	CreateUnit(*schema.Unit) error
 	DestroyUnit(string) error
 	UnitStates() ([]*schema.UnitState, error)
+	SetUnitTargetState(string, string) error
 }

--- a/server/deploys_resource.go
+++ b/server/deploys_resource.go
@@ -54,6 +54,7 @@ type UnitTemplate struct {
 	Name        string
 	Version     string
 	ImagePrefix string
+	Timestamp   string
 }
 
 // Create is the POST endpoint for kicking off a new deployment of the service
@@ -141,7 +142,7 @@ func (dr *DeploysResource) Destroy(u *url.URL, h http.Header, req interface{}) (
 // startUnits is a helper function for ensuring that Fleet has all the units
 // configured and for launching those units.
 func (dr *DeploysResource) startUnits(serviceName string, version string, timestamp string, instances int) error {
-	options := getUnitOptions(serviceName, version, dr.ImagePrefix)
+	options := getUnitOptions(UnitTemplate{serviceName, version, dr.ImagePrefix, timestamp})
 
 	// Make sure all units exist before we start setting their target states
 	for i := 1; i <= instances; i++ {
@@ -183,10 +184,10 @@ func determineNumberOfInstances(instances int, numberOfVersions int, numberOfUni
 
 // getUnitOptions renders the unit file and converts it to an array of
 // UnitOption structs.
-func getUnitOptions(name string, version string, imagePrefix string) []*schema.UnitOption {
+func getUnitOptions(unitViewTemplate UnitTemplate) []*schema.UnitOption {
 	var unitTemplate bytes.Buffer
 	t, _ := template.New("test").Parse(dockerUnitTemplate)
-	t.Execute(&unitTemplate, UnitTemplate{name, version, imagePrefix})
+	t.Execute(&unitTemplate, unitViewTemplate)
 
 	unitFile, _ := unit.NewUnitFile(unitTemplate.String())
 

--- a/server/deploys_resource.go
+++ b/server/deploys_resource.go
@@ -115,7 +115,7 @@ func (dr *DeploysResource) Create(u *url.URL, h http.Header, req *DeployRequest)
 //
 // This function assumes that it is nested inside
 // `/services/{name}/versions/{version}` and that Tigertonic is extracting the
-// service name/version/timestamp and providing it via query params.
+// service name/version and providing it via query params.
 func (dr *DeploysResource) Destroy(u *url.URL, h http.Header, req interface{}) (int, http.Header, interface{}, error) {
 	serviceName := u.Query().Get("name")
 	version := u.Query().Get("version")

--- a/server/deploys_resource.go
+++ b/server/deploys_resource.go
@@ -75,7 +75,7 @@ func (dr *DeploysResource) Create(u *url.URL, h http.Header, req *DeployRequest)
 
 	units, err := dr.Fleet.Units()
 	if err != nil {
-		log.Printf("%#v\n", err)
+		log.Println(err)
 		return http.StatusInternalServerError, nil, nil, err
 	}
 
@@ -122,7 +122,7 @@ func (dr *DeploysResource) Destroy(u *url.URL, h http.Header, req interface{}) (
 
 	units, err := dr.Fleet.Units()
 	if err != nil {
-		log.Printf("%#v\n", err)
+		log.Println(err)
 		return http.StatusInternalServerError, nil, nil, err
 	}
 	serviceUnits := FindServiceUnits(serviceName, version, units)
@@ -242,7 +242,7 @@ func (dr *DeploysResource) destroyPrevious(previousFleetUnit string, currentFlee
 						log.Printf("%s has launched, destroying %s.\n", currentFleetUnit, previousFleetUnit)
 						err := dr.Fleet.DestroyUnit(previousFleetUnit)
 						if err != nil {
-							log.Printf("%#v\n", err)
+							log.Println(err)
 						}
 						return
 					}

--- a/server/deploys_resource.go
+++ b/server/deploys_resource.go
@@ -73,7 +73,7 @@ func (dr *DeploysResource) Create(u *url.URL, h http.Header, req *DeployRequest)
 		timestamp = req.Deploy.Timestamp
 	} else {
 		t := time.Now()
-		timestamp = t.UTC().Format(time.RFC3339)
+		timestamp = t.UTC().Format("2006.01.02-15.04.05")
 	}
 
 	if req.Deploy.DestroyPrevious {
@@ -149,7 +149,7 @@ func getUnitOptions(name string, version string, imagePrefix string) []*schema.U
 // fleetServiceName generates a fleet unit name with the service name, version,
 // and instance encoded within it.
 func fleetServiceName(name string, version string, timestamp string, instance string) string {
-	return fmt.Sprintf("%s:%s_%s@%s.service", name, version, timestamp, instance)
+	return fmt.Sprintf("%s:%s:%s@%s.service", name, version, timestamp, instance)
 }
 
 // destroyPrevious is responsible for watching for a new version of a service to

--- a/server/deploys_resource.go
+++ b/server/deploys_resource.go
@@ -200,10 +200,10 @@ func fleetServiceName(name string, version string, timestamp string, instance st
 	return fmt.Sprintf("%s:%s:%s@%s.service", name, version, timestamp, instance)
 }
 
-// shouldDestroyUnit takes an optional input from the query string and, if
-// specified, ensures that it matches the unitTimestamp.  If the optional input
-// is left blank, we'll return true.  If the optional input is present and it
-// doesn't match the timestamp, we'll return false.
+// shouldDestroyUnit takes an optional timestamp (from the query string) and, if
+// specified, ensures that it matches the unitTimestamp.  If the optional
+// timestamp is left blank, we'll return true.  If the optional timestamp is
+// present and it doesn't match the timestamp, we'll return false.
 func shouldDestroyUnit(blankOrTimestampToMatch string, unitTimestamp string) bool {
 	if blankOrTimestampToMatch == "" {
 		return true

--- a/server/deploys_resource.go
+++ b/server/deploys_resource.go
@@ -82,7 +82,12 @@ func (dr *DeploysResource) Create(u *url.URL, h http.Header, req *DeployRequest)
 		}
 	}
 
-	err := dr.Fleet.CreateUnit(&schema.Unit{Name: fleetName, DesiredState: "launched", Options: options})
+	err := dr.Fleet.CreateUnit(&schema.Unit{Name: fleetName, Options: options})
+	if err != nil {
+		return http.StatusInternalServerError, nil, nil, err
+	}
+
+	err = dr.Fleet.SetUnitTargetState(fleetName, "launched")
 	if err != nil {
 		return http.StatusInternalServerError, nil, nil, err
 	}

--- a/server/deploys_resource_test.go
+++ b/server/deploys_resource_test.go
@@ -28,7 +28,8 @@ func (suite *DeploysResourceTestSuite) SetupTest() {
 
 func (suite *DeploysResourceTestSuite) TestCreateWithoutDestroyPrevious() {
 	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
-	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel-abc123@1.service", DesiredState: "launched", Options: expectedOptions}).Return(nil)
+	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel-abc123@1.service", Options: expectedOptions}).Return(nil)
+	suite.FleetClientMock.On("SetUnitTargetState", "carousel-abc123@1.service", "launched").Return(nil)
 
 	code, _, response, err := suite.Subject.Create(
 		mocking.URL(suite.Service.RootMux, "POST", "http://example.com/v1/services/carousel/deploys"),
@@ -45,7 +46,8 @@ func (suite *DeploysResourceTestSuite) TestCreateWithoutDestroyPrevious() {
 func (suite *DeploysResourceTestSuite) TestCreateWithDestroyPreviousAndNoPreviousVersions() {
 	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{}, nil)
-	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel-abc123@1.service", DesiredState: "launched", Options: expectedOptions}).Return(nil)
+	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel-abc123@1.service", Options: expectedOptions}).Return(nil)
+	suite.FleetClientMock.On("SetUnitTargetState", "carousel-abc123@1.service", "launched").Return(nil)
 
 	code, _, response, err := suite.Subject.Create(
 		mocking.URL(suite.Service.RootMux, "POST", "http://example.com/v1/services/carousel/deploys"),

--- a/server/deploys_resource_test.go
+++ b/server/deploys_resource_test.go
@@ -28,13 +28,13 @@ func (suite *DeploysResourceTestSuite) SetupTest() {
 
 func (suite *DeploysResourceTestSuite) TestCreateWithoutDestroyPrevious() {
 	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
-	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel-abc123@1.service", Options: expectedOptions}).Return(nil)
-	suite.FleetClientMock.On("SetUnitTargetState", "carousel-abc123@1.service", "launched").Return(nil)
+	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel:abc123_2013-06-05T14:10:43Z@1.service", Options: expectedOptions}).Return(nil)
+	suite.FleetClientMock.On("SetUnitTargetState", "carousel:abc123_2013-06-05T14:10:43Z@1.service", "launched").Return(nil)
 
 	code, _, response, err := suite.Subject.Create(
 		mocking.URL(suite.Service.RootMux, "POST", "http://example.com/v1/services/carousel/deploys"),
 		mocking.Header(nil),
-		&DeployRequest{Deploy{"abc123", false}},
+		&DeployRequest{Deploy{"abc123", false, "2013-06-05T14:10:43Z"}},
 	)
 
 	assert.Nil(suite.T(), err)
@@ -46,13 +46,13 @@ func (suite *DeploysResourceTestSuite) TestCreateWithoutDestroyPrevious() {
 func (suite *DeploysResourceTestSuite) TestCreateWithDestroyPreviousAndNoPreviousVersions() {
 	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{}, nil)
-	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel-abc123@1.service", Options: expectedOptions}).Return(nil)
-	suite.FleetClientMock.On("SetUnitTargetState", "carousel-abc123@1.service", "launched").Return(nil)
+	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel:abc123_2013-06-05T14:10:43Z@1.service", Options: expectedOptions}).Return(nil)
+	suite.FleetClientMock.On("SetUnitTargetState", "carousel:abc123_2013-06-05T14:10:43Z@1.service", "launched").Return(nil)
 
 	code, _, response, err := suite.Subject.Create(
 		mocking.URL(suite.Service.RootMux, "POST", "http://example.com/v1/services/carousel/deploys"),
 		mocking.Header(nil),
-		&DeployRequest{Deploy{"abc123", true}},
+		&DeployRequest{Deploy{"abc123", true, "2013-06-05T14:10:43Z"}},
 	)
 
 	assert.Nil(suite.T(), err)
@@ -63,23 +63,23 @@ func (suite *DeploysResourceTestSuite) TestCreateWithDestroyPreviousAndNoPreviou
 
 func (suite *DeploysResourceTestSuite) TestDestroyPrevious() {
 	mockedStates := []*schema.UnitState{
-		&schema.UnitState{"", "", "carousel-abc123@1.service", "", "", "running"},
+		&schema.UnitState{"", "", "carousel:cccddd_2013-06-05T14:10:43Z@1.service", "", "", "running"},
 	}
 	suite.FleetClientMock.On("UnitStates").Return(mockedStates, nil)
-	suite.FleetClientMock.On("DestroyUnit", "carousel-cccddd@1.service").Return(nil)
+	suite.FleetClientMock.On("DestroyUnit", "carousel:abc123_2013-06-05T14:10:43Z@1.service").Return(nil)
 
-	suite.Subject.destroyPrevious("carousel", "cccddd", "abc123", "1", 0)
+	suite.Subject.destroyPrevious("carousel:abc123_2013-06-05T14:10:43Z@1.service", "carousel:cccddd_2013-06-05T14:10:43Z@1.service", 0)
 
 	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
 }
 
 func (suite *DeploysResourceTestSuite) TestDestroy() {
-	suite.FleetClientMock.On("DestroyUnit", "carousel-cccddd@1.service").Return(nil)
+	suite.FleetClientMock.On("DestroyUnit", "carousel:cccddd_@1.service").Return(nil)
 
 	code, _, response, err := suite.Subject.Destroy(
 		mocking.URL(suite.Service.RootMux, "DELETE", "http://example.com/v1/services/carousel/deploys/cccddd"),
 		mocking.Header(nil),
-		&DeployRequest{Deploy{"abc123", false}},
+		&DeployRequest{Deploy{"abc123", false, "2013-06-05T14:10:43.678Z"}},
 	)
 
 	assert.Nil(suite.T(), err)

--- a/server/deploys_resource_test.go
+++ b/server/deploys_resource_test.go
@@ -68,7 +68,7 @@ func (suite *DeploysResourceTestSuite) TestDestroyPrevious() {
 	suite.FleetClientMock.On("UnitStates").Return(mockedStates, nil)
 	suite.FleetClientMock.On("DestroyUnit", "carousel-cccddd@1.service").Return(nil)
 
-	suite.Subject.destroyPrevious("carousel", "cccddd", "abc123", 0)
+	suite.Subject.destroyPrevious("carousel", "cccddd", "abc123", "1", 0)
 
 	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
 }

--- a/server/deploys_resource_test.go
+++ b/server/deploys_resource_test.go
@@ -134,7 +134,7 @@ func (suite *DeploysResourceTestSuite) TestCreateWithDestroyPreviousAndTooManyIn
 		&DeployRequest{Deploy{"abc123", true, "2006.01.02-15.04.05", 1}},
 	)
 
-	assert.Contains(suite.T(), fmt.Sprintf("%s", err), "A greater amount of instances")
+	assert.Contains(suite.T(), fmt.Sprintf("%s", err), "A greater number of instances")
 	assert.Equal(suite.T(), 400, code)
 	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
 }

--- a/server/deploys_resource_test.go
+++ b/server/deploys_resource_test.go
@@ -28,13 +28,13 @@ func (suite *DeploysResourceTestSuite) SetupTest() {
 
 func (suite *DeploysResourceTestSuite) TestCreateWithoutDestroyPrevious() {
 	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
-	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel:abc123_2013-06-05T14:10:43Z@1.service", Options: expectedOptions}).Return(nil)
-	suite.FleetClientMock.On("SetUnitTargetState", "carousel:abc123_2013-06-05T14:10:43Z@1.service", "launched").Return(nil)
+	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel:abc123:2006.01.02-15.04.05@1.service", Options: expectedOptions}).Return(nil)
+	suite.FleetClientMock.On("SetUnitTargetState", "carousel:abc123:2006.01.02-15.04.05@1.service", "launched").Return(nil)
 
 	code, _, response, err := suite.Subject.Create(
 		mocking.URL(suite.Service.RootMux, "POST", "http://example.com/v1/services/carousel/deploys"),
 		mocking.Header(nil),
-		&DeployRequest{Deploy{"abc123", false, "2013-06-05T14:10:43Z"}},
+		&DeployRequest{Deploy{"abc123", false, "2006.01.02-15.04.05"}},
 	)
 
 	assert.Nil(suite.T(), err)
@@ -46,13 +46,13 @@ func (suite *DeploysResourceTestSuite) TestCreateWithoutDestroyPrevious() {
 func (suite *DeploysResourceTestSuite) TestCreateWithDestroyPreviousAndNoPreviousVersions() {
 	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{}, nil)
-	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel:abc123_2013-06-05T14:10:43Z@1.service", Options: expectedOptions}).Return(nil)
-	suite.FleetClientMock.On("SetUnitTargetState", "carousel:abc123_2013-06-05T14:10:43Z@1.service", "launched").Return(nil)
+	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel:abc123:2006.01.02-15.04.05@1.service", Options: expectedOptions}).Return(nil)
+	suite.FleetClientMock.On("SetUnitTargetState", "carousel:abc123:2006.01.02-15.04.05@1.service", "launched").Return(nil)
 
 	code, _, response, err := suite.Subject.Create(
 		mocking.URL(suite.Service.RootMux, "POST", "http://example.com/v1/services/carousel/deploys"),
 		mocking.Header(nil),
-		&DeployRequest{Deploy{"abc123", true, "2013-06-05T14:10:43Z"}},
+		&DeployRequest{Deploy{"abc123", true, "2006.01.02-15.04.05"}},
 	)
 
 	assert.Nil(suite.T(), err)
@@ -63,23 +63,23 @@ func (suite *DeploysResourceTestSuite) TestCreateWithDestroyPreviousAndNoPreviou
 
 func (suite *DeploysResourceTestSuite) TestDestroyPrevious() {
 	mockedStates := []*schema.UnitState{
-		&schema.UnitState{"", "", "carousel:cccddd_2013-06-05T14:10:43Z@1.service", "", "", "running"},
+		&schema.UnitState{"", "", "carousel:cccddd:2006.01.02-15.04.05@1.service", "", "", "running"},
 	}
 	suite.FleetClientMock.On("UnitStates").Return(mockedStates, nil)
-	suite.FleetClientMock.On("DestroyUnit", "carousel:abc123_2013-06-05T14:10:43Z@1.service").Return(nil)
+	suite.FleetClientMock.On("DestroyUnit", "carousel:abc123:2006.01.02-15.04.05@1.service").Return(nil)
 
-	suite.Subject.destroyPrevious("carousel:abc123_2013-06-05T14:10:43Z@1.service", "carousel:cccddd_2013-06-05T14:10:43Z@1.service", 0)
+	suite.Subject.destroyPrevious("carousel:abc123:2006.01.02-15.04.05@1.service", "carousel:cccddd:2006.01.02-15.04.05@1.service", 0)
 
 	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
 }
 
 func (suite *DeploysResourceTestSuite) TestDestroy() {
-	suite.FleetClientMock.On("DestroyUnit", "carousel:cccddd_@1.service").Return(nil)
+	suite.FleetClientMock.On("DestroyUnit", "carousel:cccddd:@1.service").Return(nil)
 
 	code, _, response, err := suite.Subject.Destroy(
 		mocking.URL(suite.Service.RootMux, "DELETE", "http://example.com/v1/services/carousel/deploys/cccddd"),
 		mocking.Header(nil),
-		&DeployRequest{Deploy{"abc123", false, "2013-06-05T14:10:43.678Z"}},
+		&DeployRequest{Deploy{"abc123", false, "2006.01.02-15.04.05"}},
 	)
 
 	assert.Nil(suite.T(), err)

--- a/server/deploys_resource_test.go
+++ b/server/deploys_resource_test.go
@@ -28,7 +28,7 @@ func (suite *DeploysResourceTestSuite) SetupTest() {
 }
 
 func (suite *DeploysResourceTestSuite) TestCreateWithoutPassedInstancesAndNoInstancesRunning() {
-	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
+	expectedOptions := getUnitOptions(UnitTemplate{"carousel", "abc123", "mmmhm", "2006.01.02-15.04.05"})
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{}, nil)
 
 	// Should only start 1 unit
@@ -45,7 +45,7 @@ func (suite *DeploysResourceTestSuite) TestCreateWithoutPassedInstancesAndNoInst
 }
 
 func (suite *DeploysResourceTestSuite) TestCreateWithoutPassedInstancesAndMultipleInstancesRunning() {
-	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
+	expectedOptions := getUnitOptions(UnitTemplate{"carousel", "abc123", "mmmhm", "2006.01.02-15.04.05"})
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{
 		&schema.Unit{"running", "running", "efefeff", "carousel:efefeff:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}},
 		&schema.Unit{"running", "running", "efefeff", "carousel:efefeff:2006.01.02-15.04.05@2.service", []*schema.UnitOption{}},
@@ -67,7 +67,7 @@ func (suite *DeploysResourceTestSuite) TestCreateWithoutPassedInstancesAndMultip
 }
 
 func (suite *DeploysResourceTestSuite) TestCreateWithoutPassedInstancesAndMultipleVersionsRunning() {
-	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
+	expectedOptions := getUnitOptions(UnitTemplate{"carousel", "abc123", "mmmhm", "2006.01.02-15.04.05"})
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{
 		&schema.Unit{"running", "running", "efefeff", "carousel:efefeff:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}},
 		&schema.Unit{"running", "running", "abbbbbb", "carousel:abbbbbb:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}},
@@ -87,7 +87,7 @@ func (suite *DeploysResourceTestSuite) TestCreateWithoutPassedInstancesAndMultip
 }
 
 func (suite *DeploysResourceTestSuite) TestCreateWithoutDestroyPrevious() {
-	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
+	expectedOptions := getUnitOptions(UnitTemplate{"carousel", "abc123", "mmmhm", "2006.01.02-15.04.05"})
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{}, nil)
 	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel:abc123:2006.01.02-15.04.05@1.service", Options: expectedOptions}).Return(nil)
 	suite.FleetClientMock.On("SetUnitTargetState", "carousel:abc123:2006.01.02-15.04.05@1.service", "launched").Return(nil)
@@ -105,7 +105,7 @@ func (suite *DeploysResourceTestSuite) TestCreateWithoutDestroyPrevious() {
 }
 
 func (suite *DeploysResourceTestSuite) TestCreateWithDestroyPreviousAndNoPreviousVersions() {
-	expectedOptions := getUnitOptions("carousel", "abc123", "mmmhm")
+	expectedOptions := getUnitOptions(UnitTemplate{"carousel", "abc123", "mmmhm", "2006.01.02-15.04.05"})
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{}, nil)
 	suite.FleetClientMock.On("CreateUnit", &schema.Unit{Name: "carousel:abc123:2006.01.02-15.04.05@1.service", Options: expectedOptions}).Return(nil)
 	suite.FleetClientMock.On("SetUnitTargetState", "carousel:abc123:2006.01.02-15.04.05@1.service", "launched").Return(nil)

--- a/server/extractable_unit.go
+++ b/server/extractable_unit.go
@@ -12,22 +12,22 @@ import (
 type ExtractableUnit schema.Unit
 
 // ExtractBaseName returns the name of the service from the Fleet unit name.
-// Given "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service" this returns "railsapp"
+// Given "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service" this returns "railsapp"
 func (eu *ExtractableUnit) ExtractBaseName() string {
 	s := strings.Index(eu.Name, ":")
 	return eu.Name[0:s]
 }
 
 // ExtractVersion returns the version of the service from the Fleet unit name.
-// Given "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service" this returns "cf2e8ac"
+// Given "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service" this returns "cf2e8ac"
 func (eu *ExtractableUnit) ExtractVersion() string {
 	start := strings.Index(eu.Name, ":")
-	end := strings.LastIndex(eu.Name, "_")
+	end := strings.LastIndex(eu.Name, ":")
 	return eu.Name[start+1 : end]
 }
 
 // ExtractInstance returns the instance of the service from the Fleet unit name.
-// Given "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service" this returns "1"
+// Given "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service" this returns "1"
 func (eu *ExtractableUnit) ExtractInstance() string {
 	start := strings.LastIndex(eu.Name, "@")
 	end := strings.LastIndex(eu.Name, ".")
@@ -36,10 +36,10 @@ func (eu *ExtractableUnit) ExtractInstance() string {
 
 // ExtractTimestamp returns the deploy timestamp that is appended to the Fleet
 // unit name.
-// Given "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service" this returns
+// Given "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service" this returns
 // "2013-06-05T14:10:43Z"
 func (eu *ExtractableUnit) ExtractTimestamp() string {
-	start := strings.LastIndex(eu.Name, "_")
+	start := strings.LastIndex(eu.Name, ":")
 	end := strings.LastIndex(eu.Name, "@")
 	return eu.Name[start+1 : end]
 }

--- a/server/extractable_unit.go
+++ b/server/extractable_unit.go
@@ -12,24 +12,34 @@ import (
 type ExtractableUnit schema.Unit
 
 // ExtractBaseName returns the name of the service from the Fleet unit name.
-// Given "railsapp-cf2e8ac@1.service" this returns "railsapp"
+// Given "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service" this returns "railsapp"
 func (eu *ExtractableUnit) ExtractBaseName() string {
-	s := strings.LastIndex(eu.Name, "-")
+	s := strings.Index(eu.Name, ":")
 	return eu.Name[0:s]
 }
 
 // ExtractVersion returns the version of the service from the Fleet unit name.
-// Given "railsapp-cf2e8ac@1.service" this returns "cf2e8ac"
+// Given "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service" this returns "cf2e8ac"
 func (eu *ExtractableUnit) ExtractVersion() string {
-	start := strings.LastIndex(eu.Name, "-")
-	end := strings.LastIndex(eu.Name, "@")
+	start := strings.Index(eu.Name, ":")
+	end := strings.LastIndex(eu.Name, "_")
 	return eu.Name[start+1 : end]
 }
 
 // ExtractInstance returns the instance of the service from the Fleet unit name.
-// Given "railsapp-cf2e8ac@1.service" this returns "1"
+// Given "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service" this returns "1"
 func (eu *ExtractableUnit) ExtractInstance() string {
-	s := strings.Split(eu.Name, "@")
-	end := strings.Index(s[1], ".")
-	return s[1][:end]
+	start := strings.LastIndex(eu.Name, "@")
+	end := strings.LastIndex(eu.Name, ".")
+	return eu.Name[start+1 : end]
+}
+
+// ExtractTimestamp returns the deploy timestamp that is appended to the Fleet
+// unit name.
+// Given "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service" this returns
+// "2013-06-05T14:10:43Z"
+func (eu *ExtractableUnit) ExtractTimestamp() string {
+	start := strings.LastIndex(eu.Name, "_")
+	end := strings.LastIndex(eu.Name, "@")
+	return eu.Name[start+1 : end]
 }

--- a/server/extractable_unit_test.go
+++ b/server/extractable_unit_test.go
@@ -12,23 +12,23 @@ type ExtractableUnitTestSuite struct {
 }
 
 func (suite *ExtractableUnitTestSuite) TestExtractsBaseName() {
-	subject := ExtractableUnit{Name: "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service"}
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service"}
 	assert.Equal(suite.T(), "railsapp", subject.ExtractBaseName())
 }
 
 func (suite *ExtractableUnitTestSuite) TestExtractsVersion() {
-	subject := ExtractableUnit{Name: "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service"}
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service"}
 	assert.Equal(suite.T(), "cf2e8ac", subject.ExtractVersion())
 }
 
 func (suite *ExtractableUnitTestSuite) TestExtractsInstance() {
-	subject := ExtractableUnit{Name: "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service"}
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service"}
 	assert.Equal(suite.T(), "1", subject.ExtractInstance())
 }
 
 func (suite *ExtractableUnitTestSuite) TestExtractsTimestamp() {
-	subject := ExtractableUnit{Name: "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service"}
-	assert.Equal(suite.T(), "2013-06-05T14:10:43Z", subject.ExtractTimestamp())
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service"}
+	assert.Equal(suite.T(), "2006.01.02-15.04.05", subject.ExtractTimestamp())
 }
 
 func TestExtractableUnitTestSuite(t *testing.T) {

--- a/server/extractable_unit_test.go
+++ b/server/extractable_unit_test.go
@@ -1,9 +1,10 @@
 package server
 
 import (
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/suite"
-	"testing"
 )
 
 type ExtractableUnitTestSuite struct {
@@ -11,28 +12,23 @@ type ExtractableUnitTestSuite struct {
 }
 
 func (suite *ExtractableUnitTestSuite) TestExtractsBaseName() {
-	subject := ExtractableUnit{Name: "railsapp-efe1abc@1.service"}
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service"}
 	assert.Equal(suite.T(), "railsapp", subject.ExtractBaseName())
 }
 
-func (suite *ExtractableUnitTestSuite) TestExtractsBaseNameSupportsNamesWithHyphens() {
-	subject := ExtractableUnit{Name: "hello-world-efe1abc@1.service"}
-	assert.Equal(suite.T(), "hello-world", subject.ExtractBaseName())
-}
-
 func (suite *ExtractableUnitTestSuite) TestExtractsVersion() {
-	subject := ExtractableUnit{Name: "railsapp-efe1abc@1.service"}
-	assert.Equal(suite.T(), "efe1abc", subject.ExtractVersion())
-}
-
-func (suite *ExtractableUnitTestSuite) TestExtractsVersionWithHyphenatedName() {
-	subject := ExtractableUnit{Name: "hellow-world-efe1abc@1.service"}
-	assert.Equal(suite.T(), "efe1abc", subject.ExtractVersion())
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service"}
+	assert.Equal(suite.T(), "cf2e8ac", subject.ExtractVersion())
 }
 
 func (suite *ExtractableUnitTestSuite) TestExtractsInstance() {
-	subject := ExtractableUnit{Name: "railsapp-efe1abc@1.service"}
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service"}
 	assert.Equal(suite.T(), "1", subject.ExtractInstance())
+}
+
+func (suite *ExtractableUnitTestSuite) TestExtractsTimestamp() {
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service"}
+	assert.Equal(suite.T(), "2013-06-05T14:10:43Z", subject.ExtractTimestamp())
 }
 
 func TestExtractableUnitTestSuite(t *testing.T) {

--- a/server/mocks/fleet_client.go
+++ b/server/mocks/fleet_client.go
@@ -1,6 +1,7 @@
 package mocks
 
 import "github.com/stretchr/testify/mock"
+
 import "github.com/coreos/fleet/schema"
 
 type FleetClient struct {
@@ -36,4 +37,11 @@ func (m *FleetClient) UnitStates() ([]*schema.UnitState, error) {
 	r1 := ret.Error(1)
 
 	return r0, r1
+}
+func (m *FleetClient) SetUnitTargetState(_a0 string, _a1 string) error {
+	ret := m.Called(_a0, _a1)
+
+	r0 := ret.Error(0)
+
+	return r0
 }

--- a/server/templates.go
+++ b/server/templates.go
@@ -10,7 +10,7 @@ package server
 // structs before sending it off to the Fleet client.
 const dockerUnitTemplate = `
 [Unit]
-Description={{.Name}}
+Description={{.Name}}-{{.Version}}
 After=docker.service
 
 [Service]
@@ -20,6 +20,6 @@ TimeoutStartSec=0
 ExecStartPre=/usr/bin/docker pull {{.ImagePrefix}}/{{.Name}}:{{.Version}}
 ExecStartPre=-/usr/bin/docker rm -f {{.Name}}-{{.Version}}-%i
 ExecStart=/usr/bin/docker run --name {{.Name}}-{{.Version}}-%i -p 3000 {{.ImagePrefix}}/{{.Name}}:{{.Version}}
-ExecStartPost=/bin/sh -c "sleep 15; /usr/bin/etcdctl set /vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-%i http://$COREOS_PRIVATE_IPV4:$(echo $(/usr/bin/docker port {{.Name}}-{{.Version}}-%i 3000) | cut -d ':' -f 2)"
+ExecStartPost=/bin/sh -c "sleep 3; /usr/bin/etcdctl set /vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-%i http://$COREOS_PRIVATE_IPV4:$(echo $(/usr/bin/docker port {{.Name}}-{{.Version}}-%i 3000) | cut -d ':' -f 2)"
 ExecStop=/bin/sh -c "/usr/bin/etcdctl rm '/vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-%i' ; /usr/bin/docker rm -f {{.Name}}-{{.Version}}-%i"
 `

--- a/server/templates.go
+++ b/server/templates.go
@@ -10,7 +10,7 @@ package server
 // structs before sending it off to the Fleet client.
 const dockerUnitTemplate = `
 [Unit]
-Description={{.Name}}-{{.Version}}
+Description={{.Name}}-{{.Version}}-{{.Timestamp}}
 After=docker.service
 
 [Service]
@@ -18,8 +18,8 @@ EnvironmentFile=/etc/environment
 User=core
 TimeoutStartSec=0
 ExecStartPre=/usr/bin/docker pull {{.ImagePrefix}}/{{.Name}}:{{.Version}}
-ExecStartPre=-/usr/bin/docker rm -f {{.Name}}-{{.Version}}-%i
-ExecStart=/usr/bin/docker run --name {{.Name}}-{{.Version}}-%i -p 3000 {{.ImagePrefix}}/{{.Name}}:{{.Version}}
-ExecStartPost=/bin/sh -c "sleep 3; /usr/bin/etcdctl set /vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-%i http://$COREOS_PRIVATE_IPV4:$(echo $(/usr/bin/docker port {{.Name}}-{{.Version}}-%i 3000) | cut -d ':' -f 2)"
-ExecStop=/bin/sh -c "/usr/bin/etcdctl rm '/vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-%i' ; /usr/bin/docker rm -f {{.Name}}-{{.Version}}-%i"
+ExecStartPre=-/usr/bin/docker rm -f {{.Name}}-{{.Version}}-{{.Timestamp}}-%i
+ExecStart=/usr/bin/docker run --name {{.Name}}-{{.Version}}-{{.Timestamp}}-%i -p 3000 {{.ImagePrefix}}/{{.Name}}:{{.Version}}
+ExecStartPost=/bin/sh -c "sleep 3; /usr/bin/etcdctl set /vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-{{.Timestamp}}-%i http://$COREOS_PRIVATE_IPV4:$(echo $(/usr/bin/docker port {{.Name}}-{{.Version}}-{{.Timestamp}}-%i 3000) | cut -d ':' -f 2)"
+ExecStop=/bin/sh -c "/usr/bin/etcdctl rm '/vulcand/upstreams/{{.Name}}/endpoints/{{.Name}}-{{.Version}}-{{.Timestamp}}-%i' ; /usr/bin/docker rm -f {{.Name}}-{{.Version}}-{{.Timestamp}}-%i"
 `

--- a/server/units_resource.go
+++ b/server/units_resource.go
@@ -30,7 +30,7 @@ func (ur *UnitsResource) Index(u *url.URL, h http.Header, req interface{}) (int,
 
 	units, err := ur.Fleet.Units()
 	if err != nil {
-		log.Printf("%#v\n", err)
+		log.Println(err)
 		return http.StatusInternalServerError, nil, nil, err
 	}
 	response.Units = FindServiceUnits(u.Query().Get("name"), "", units)

--- a/server/units_resource.go
+++ b/server/units_resource.go
@@ -33,7 +33,7 @@ func (ur *UnitsResource) Index(u *url.URL, h http.Header, req interface{}) (int,
 		log.Printf("%#v\n", err)
 		return http.StatusInternalServerError, nil, nil, err
 	}
-	response.Units = FindServiceUnits(u.Query().Get("name"), units)
+	response.Units = FindServiceUnits(u.Query().Get("name"), "", units)
 
 	return statusCode, nil, response, nil
 }

--- a/server/units_resource_test.go
+++ b/server/units_resource_test.go
@@ -42,7 +42,7 @@ func (suite *UnitsResourceTestSuite) TestIndexWithNoResults() {
 }
 
 func (suite *UnitsResourceTestSuite) TestIndexWithNoMatchingResultsForService() {
-	suite.FleetClientMock.On("Units").Return([]*schema.Unit{&schema.Unit{"running", "running", "abc123", "differentapp-efefeff@1.service", []*schema.UnitOption{}}}, nil)
+	suite.FleetClientMock.On("Units").Return([]*schema.Unit{&schema.Unit{"running", "running", "abc123", "differentapp:efefeff_2013-06-05T14:10:43Z@1.service", []*schema.UnitOption{}}}, nil)
 
 	code, _, response, err := suite.Subject.Index(
 		mocking.URL(suite.Service.RootMux, "GET", "http://example.com/v1/services/carousel/units"),
@@ -57,7 +57,7 @@ func (suite *UnitsResourceTestSuite) TestIndexWithNoMatchingResultsForService() 
 }
 
 func (suite *UnitsResourceTestSuite) TestIndexWithMatchingResultsForService() {
-	suite.FleetClientMock.On("Units").Return([]*schema.Unit{&schema.Unit{"running", "running", "abc123", "carousel-efefeff@1.service", []*schema.UnitOption{}}}, nil)
+	suite.FleetClientMock.On("Units").Return([]*schema.Unit{&schema.Unit{"running", "running", "abc123", "carousel:efefeff_2013-06-05T14:10:43Z@1.service", []*schema.UnitOption{}}}, nil)
 
 	code, _, response, err := suite.Subject.Index(
 		mocking.URL(suite.Service.RootMux, "GET", "http://example.com/v1/services/carousel/units"),
@@ -67,7 +67,7 @@ func (suite *UnitsResourceTestSuite) TestIndexWithMatchingResultsForService() {
 
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 200, code)
-	assert.Equal(suite.T(), &UnitsResponse{Units: []VersionedUnit{VersionedUnit{Service: "carousel", Instance: "1", Version: "efefeff", CurrentState: "running", DesiredState: "running", MachineID: "abc123"}}}, response)
+	assert.Equal(suite.T(), &UnitsResponse{Units: []VersionedUnit{VersionedUnit{Service: "carousel", Instance: "1", Version: "efefeff", CurrentState: "running", DesiredState: "running", MachineID: "abc123", Timestamp: "2013-06-05T14:10:43Z"}}}, response)
 	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
 }
 

--- a/server/units_resource_test.go
+++ b/server/units_resource_test.go
@@ -42,7 +42,7 @@ func (suite *UnitsResourceTestSuite) TestIndexWithNoResults() {
 }
 
 func (suite *UnitsResourceTestSuite) TestIndexWithNoMatchingResultsForService() {
-	suite.FleetClientMock.On("Units").Return([]*schema.Unit{&schema.Unit{"running", "running", "abc123", "differentapp:efefeff_2013-06-05T14:10:43Z@1.service", []*schema.UnitOption{}}}, nil)
+	suite.FleetClientMock.On("Units").Return([]*schema.Unit{&schema.Unit{"running", "running", "abc123", "differentapp:efefeff:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}}}, nil)
 
 	code, _, response, err := suite.Subject.Index(
 		mocking.URL(suite.Service.RootMux, "GET", "http://example.com/v1/services/carousel/units"),
@@ -57,7 +57,7 @@ func (suite *UnitsResourceTestSuite) TestIndexWithNoMatchingResultsForService() 
 }
 
 func (suite *UnitsResourceTestSuite) TestIndexWithMatchingResultsForService() {
-	suite.FleetClientMock.On("Units").Return([]*schema.Unit{&schema.Unit{"running", "running", "abc123", "carousel:efefeff_2013-06-05T14:10:43Z@1.service", []*schema.UnitOption{}}}, nil)
+	suite.FleetClientMock.On("Units").Return([]*schema.Unit{&schema.Unit{"running", "running", "abc123", "carousel:efefeff:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}}}, nil)
 
 	code, _, response, err := suite.Subject.Index(
 		mocking.URL(suite.Service.RootMux, "GET", "http://example.com/v1/services/carousel/units"),
@@ -67,7 +67,7 @@ func (suite *UnitsResourceTestSuite) TestIndexWithMatchingResultsForService() {
 
 	assert.Nil(suite.T(), err)
 	assert.Equal(suite.T(), 200, code)
-	assert.Equal(suite.T(), &UnitsResponse{Units: []VersionedUnit{VersionedUnit{Service: "carousel", Instance: "1", Version: "efefeff", CurrentState: "running", DesiredState: "running", MachineID: "abc123", Timestamp: "2013-06-05T14:10:43Z"}}}, response)
+	assert.Equal(suite.T(), &UnitsResponse{Units: []VersionedUnit{VersionedUnit{Service: "carousel", Instance: "1", Version: "efefeff", CurrentState: "running", DesiredState: "running", MachineID: "abc123", Timestamp: "2006.01.02-15.04.05"}}}, response)
 	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
 }
 

--- a/server/versioned_unit.go
+++ b/server/versioned_unit.go
@@ -21,7 +21,11 @@ type VersionedUnit struct {
 // Fleet unit name.  It collects all those units and returns an array of
 // VersionedUnit structs that have had their additional deployster-specific
 // fields populated from the Fleet unit name.
-func FindServiceUnits(serviceName string, units []*schema.Unit) []VersionedUnit {
+//
+// Optional filtering by version is available too.  If all versions are desired,
+// set version to "".  If a specific version is desired, set version to that
+// version.
+func FindServiceUnits(serviceName string, version string, units []*schema.Unit) []VersionedUnit {
 	versionedUnits := []VersionedUnit{}
 
 	for _, u := range units {
@@ -37,7 +41,9 @@ func FindServiceUnits(serviceName string, units []*schema.Unit) []VersionedUnit 
 				DesiredState: extractable.DesiredState,
 				MachineID:    extractable.MachineID,
 			}
-			versionedUnits = append(versionedUnits, i)
+			if shouldIncludeVersion(version, i.Version) {
+				versionedUnits = append(versionedUnits, i)
+			}
 		}
 	}
 
@@ -65,4 +71,17 @@ func FindServiceVersions(serviceName string, units []*schema.Unit) []string {
 	}
 
 	return versions
+}
+
+// shouldIncludeVersion takes an optional version checker and, if specified,
+// ensures that it matches the unitVersion.  If the optional version is left
+// blank, we'll return true.  If the optional version is present and it doesn't
+// match the unitVersion, we'll return false.
+func shouldIncludeVersion(blankOrVersion string, unitVersion string) bool {
+	if blankOrVersion == "" {
+		return true
+	} else if blankOrVersion == unitVersion {
+		return true
+	}
+	return false
 }

--- a/server/versioned_unit.go
+++ b/server/versioned_unit.go
@@ -13,6 +13,7 @@ type VersionedUnit struct {
 	CurrentState string `json:"current_state"`
 	DesiredState string `json:"desired_state"`
 	MachineID    string `json:"machine_id"`
+	Timestamp    string `json:"deploy_timestamp"`
 }
 
 // FindServiceUnits parses an array of units returned from fleet and looks for
@@ -31,6 +32,7 @@ func FindServiceUnits(serviceName string, units []*schema.Unit) []VersionedUnit 
 				Service:      serviceName,
 				Instance:     extractable.ExtractInstance(),
 				Version:      extractable.ExtractVersion(),
+				Timestamp:    extractable.ExtractTimestamp(),
 				CurrentState: extractable.CurrentState,
 				DesiredState: extractable.DesiredState,
 				MachineID:    extractable.MachineID,


### PR DESCRIPTION
This is the WIP pull request for adding support for launching multiple units of a service at deploy time.  This addresses #6.

### Things that have been added or changed
* The way deployster starts units now matches how `fleetctl` does it by loading the unit and setting the state of the unit to "launched" in a second request.
* The naming scheme of the Fleet Unit has changed to accommodate a bug with Fleet (coreos/fleet#1131).  Units now include a timestamp in their name (e.g. `railsapp:cf2e8ac_2013-06-05T14:10:43Z@1.service`)
* Cleanup of how we use `fleetServiceName` in many cases

### Todo
* [x] `DELETE /v1/services/{name}/deploys/{version}` is currently broken since timestamp has been added.
  * We need to take the service name and version and look for all instances so we can match any timestamp that is running and destroy it.
* [x] Change FindServiceUnits to take a version and only return units that match both service and version.
  * This will be used for handling the mismatched number of units and unspecified number of instances below.
* [x] Allow number of instances to be passed to the `POST` endpoint for deploys.
  * ~~Unsure yet if this should be a raw number of instances or a range to pass to fleet to start.~~ (we're just going to allow a number of instances for now)
    * The benefit of a range is that we could easily start up more units with a deploy.
    * Alternatively, we could add more units of the same version with a flag as well (or maybe a separate endpoint)
* [x] Better handling for a mismatched number of units.
  * If we have 5 running and we try to deploy 4, what do we do with the last remaining one? (for now we'll fail out if we try to deploy fewer than are currently running)
* [x] If a number of instances isn't specified, we should start either one instance or a number equal to what's already running
* [x] Fix bug with Docker containers crashing when trying to deploy the same version (because the container name is the same as it doesn't include the timestamp).
  * Possible fixes for this:
    * ~~Rename the docker containers on the fly so that the names don't conflict.  This would require Docker 1.5.0+~~
    * Include the timestamp in the docker container name.  This makes working with the containers a little harder.