### PR TITLE
Add IsManaged() check before trying to handle extracted units

### DIFF
--- a/server/deploys_resource_test.go
+++ b/server/deploys_resource_test.go
@@ -205,6 +205,28 @@ func (suite *DeploysResourceTestSuite) TestDestroyMultipleInstances() {
 	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
 }
 
+func (suite *DeploysResourceTestSuite) TestDestroyWithUnmanagedUnits() {
+	suite.FleetClientMock.On("Units").Return([]*schema.Unit{
+		&schema.Unit{"running", "running", "efefeff", "carousel:efefeff:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}},
+		&schema.Unit{"running", "running", "efefeff", "carousel:efefeff:2006.01.02-15.04.05@2.service", []*schema.UnitOption{}},
+		&schema.Unit{"running", "running", "3e33333", "carousel:3e33333:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}},
+		&schema.Unit{"running", "running", "3e33333", "vulcand.service", []*schema.UnitOption{}},
+	}, nil)
+	suite.FleetClientMock.On("DestroyUnit", "carousel:efefeff:2006.01.02-15.04.05@1.service").Return(nil)
+	suite.FleetClientMock.On("DestroyUnit", "carousel:efefeff:2006.01.02-15.04.05@2.service").Return(nil)
+
+	code, _, response, err := suite.Subject.Destroy(
+		mocking.URL(suite.Service.RootMux, "DELETE", "http://example.com/v1/services/carousel/deploys/efefeff"),
+		mocking.Header(nil),
+		&DeployRequest{Deploy{"efefeff", false, "2006.01.02-15.04.05", 1}},
+	)
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 204, code)
+	assert.Equal(suite.T(), nil, response)
+	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
+}
+
 func (suite *DeploysResourceTestSuite) TestDestroyMultipleInstancesWithTimestampSpecified() {
 	suite.FleetClientMock.On("Units").Return([]*schema.Unit{
 		&schema.Unit{"running", "running", "efefeff", "carousel:efefeff:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}},

--- a/server/extractable_unit.go
+++ b/server/extractable_unit.go
@@ -13,6 +13,13 @@ type ExtractableUnit schema.Unit
 
 // ExtractBaseName returns the name of the service from the Fleet unit name.
 // Given "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service" this returns "railsapp"
+func (eu *ExtractableUnit) IsManaged() bool {
+	s := strings.Count(eu.Name, ":")
+	return s == 2
+}
+
+// ExtractBaseName returns the name of the service from the Fleet unit name.
+// Given "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service" this returns "railsapp"
 func (eu *ExtractableUnit) ExtractBaseName() string {
 	s := strings.Index(eu.Name, ":")
 	return eu.Name[0:s]

--- a/server/extractable_unit_test.go
+++ b/server/extractable_unit_test.go
@@ -11,6 +11,16 @@ type ExtractableUnitTestSuite struct {
 	suite.Suite
 }
 
+func (suite *ExtractableUnitTestSuite) TestIsManaged() {
+	subject := ExtractableUnit{Name: "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service"}
+	assert.True(suite.T(), subject.IsManaged())
+}
+
+func (suite *ExtractableUnitTestSuite) TestIsNotManaged() {
+	subject := ExtractableUnit{Name: "vulcand.service"}
+	assert.False(suite.T(), subject.IsManaged())
+}
+
 func (suite *ExtractableUnitTestSuite) TestExtractsBaseName() {
 	subject := ExtractableUnit{Name: "railsapp:cf2e8ac:2006.01.02-15.04.05@1.service"}
 	assert.Equal(suite.T(), "railsapp", subject.ExtractBaseName())

--- a/server/units_resource_test.go
+++ b/server/units_resource_test.go
@@ -71,6 +71,24 @@ func (suite *UnitsResourceTestSuite) TestIndexWithMatchingResultsForService() {
 	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
 }
 
+func (suite *UnitsResourceTestSuite) TestIndexWithNonDeploysterManagedUnits() {
+	suite.FleetClientMock.On("Units").Return([]*schema.Unit{
+		&schema.Unit{"running", "running", "abc123", "carousel:efefeff:2006.01.02-15.04.05@1.service", []*schema.UnitOption{}},
+		&schema.Unit{"running", "running", "abc123", "vulcand.service", []*schema.UnitOption{}},
+	}, nil)
+
+	code, _, response, err := suite.Subject.Index(
+		mocking.URL(suite.Service.RootMux, "GET", "http://example.com/v1/services/carousel/units"),
+		mocking.Header(nil),
+		nil,
+	)
+
+	assert.Nil(suite.T(), err)
+	assert.Equal(suite.T(), 200, code)
+	assert.Equal(suite.T(), &UnitsResponse{Units: []VersionedUnit{VersionedUnit{Service: "carousel", Instance: "1", Version: "efefeff", CurrentState: "running", DesiredState: "running", MachineID: "abc123", Timestamp: "2006.01.02-15.04.05"}}}, response)
+	suite.FleetClientMock.Mock.AssertExpectations(suite.T())
+}
+
 func TestUnitsResourceTestSuite(t *testing.T) {
 	suite.Run(t, new(UnitsResourceTestSuite))
 }

--- a/server/versioned_unit.go
+++ b/server/versioned_unit.go
@@ -31,7 +31,7 @@ func FindServiceUnits(serviceName string, version string, units []*schema.Unit) 
 	for _, u := range units {
 		dereferencedUnit := *u
 		extractable := ExtractableUnit(dereferencedUnit)
-		if extractable.ExtractBaseName() == serviceName {
+		if extractable.IsManaged() && extractable.ExtractBaseName() == serviceName {
 			i := VersionedUnit{
 				Service:      serviceName,
 				Instance:     extractable.ExtractInstance(),
@@ -60,7 +60,7 @@ func FindServiceVersions(serviceName string, units []*schema.Unit) []string {
 	for _, u := range units {
 		dereferencedUnit := *u
 		extractable := ExtractableUnit(dereferencedUnit)
-		if extractable.ExtractBaseName() == serviceName {
+		if extractable.IsManaged() && extractable.ExtractBaseName() == serviceName {
 			uniqueVersions[extractable.ExtractVersion()] = true
 		}
 	}


### PR DESCRIPTION
This PR adds coverage and fixes a bug around when units not-managed by Deployster (and don't follow the naming convention) are present in the cluster.  This fixes #38.