### PR TITLE
Enable flannel in Vagrantfile

### DIFF
--- a/vagrant/cloud-config.yml
+++ b/vagrant/cloud-config.yml
@@ -11,6 +11,13 @@ coreos:
       command: start
     - name: fleet.service
       command: start
+    - name: flanneld.service
+      drop-ins:
+        - name: 50-network-config.conf
+          content: |
+            [Service]
+            ExecStartPre=/usr/bin/etcdctl set /coreos.com/network/config '{ "Network": "10.1.0.0/16" }'
+      command: start
     - name: docker-tcp.socket
       command: start
       enable: true

--- a/vagrant/cloud-config.yml
+++ b/vagrant/cloud-config.yml
@@ -6,6 +6,8 @@ coreos:
     peer-addr: $public_ipv4:7001
   fleet:
     public-ip: $public_ipv4
+  flannel:
+    interface: $public_ipv4
   units:
     - name: etcd.service
       command: start


### PR DESCRIPTION
Although we're not using flannel in deployster yet, this adds it to the `cloud-config.yml` that our `Vagrantfile` uses so we can begin to test how deployster can interact with these containers directly.

This goes along with #49.